### PR TITLE
Remove cargo audit

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -23,11 +23,9 @@ jobs:
       - uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # pin@v1.0.6
         with:
           toolchain: stable
-      - run: cargo install cargo-edit cargo-audit
-      - run: cd src/test/rust/simulator && cargo upgrade && cargo update && cargo audit
-          && cargo test
-      - run: cd src/main/rust/cardtool && cargo upgrade && cargo update && cargo audit
-          && cargo test
+      - run: cargo install cargo-edit
+      - run: cd src/test/rust/simulator && cargo upgrade && cargo update && cargo test
+      - run: cd src/main/rust/cardtool && cargo upgrade && cargo update && cargo test
       # NOTE: checkstyle version is fixed in build.gradle
       - run: gradle dependencies --write-locks
       - run: gradle --write-verification-metadata sha512 help


### PR DESCRIPTION
We don't really want to prevent updates from happening even if cargo audit findings something